### PR TITLE
add a csv output type backed by lines factory function

### DIFF
--- a/output/lines.go
+++ b/output/lines.go
@@ -57,9 +57,8 @@ func (lines *OutputLines) Stop() {
 	lines.Close()
 }
 
-func init() {
-	factory.RegisterOutput("lines", func(args []string) (lines api.Output, err error) {
-		outputLines := &OutputLines{}
+var lines_func =  func(args []string) (lines api.Output, err error) {
+   outputLines := &OutputLines{}
 		var file string
 		outputLines.delimiter = ","
 		outputLines.fields = []string{FIELD_WILDCARD}
@@ -100,5 +99,9 @@ func init() {
 			outputLines.writer.Flush()
 		}
 		return outputLines, nil
-	})
+}
+
+func init() {
+	factory.RegisterOutput("lines", lines_func)
+	factory.RegisterOutput("csv", lines_func)
 }


### PR DESCRIPTION
With ruby dap if I take a json input and try to do a csv output:

```
$ echo '{"foo":"bar", "baz":"qux", "a":"b"}'  | dap json + csv
bar,qux,b
```
If I try with godap:
```
$ echo '{"foo":"bar", "baz":"qux", "a":"b"}'  | /Users/ssikdar/go/bin/godap json + csv
Error: Invalid output plugin: csv
```

Comparing the available outputs:

```
$ dap --outputs
Outputs:
  * lines
  * json
  * csv
```

```
$ /Users/ssikdar/go/bin/godap  --outputs
Outputs:
 * lines
 * json
```

However at a quick look, looks like `lines` in fact is basically doing the function of csv w/ delims etc. ( Not sure if this completely true, I just took a quick look)

My change was to register another `RegisterOutput` w/ factory function with `csv` (but maybe it should be in a `csv.go` ?)

With my change:
```
$ go build -o dappy
$ ./dappy --outputs
Outputs:
 * json
 * lines
 * csv
$ echo '{"foo":"bar", "baz":"qux", "a":"b"}'  | ./dappy json + csv
bar,qux,b

```