### PR TITLE
Add recog support

### DIFF
--- a/Dockerfile.bats_testing
+++ b/Dockerfile.bats_testing
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh /usr
 
 # install godap requirements
-RUN apt-get install -y libpcap0.8-dev libgeoip-dev
+RUN apt-get install -y libpcap0.8-dev libgeoip-dev jq
 
 # build and install godap, but call it *dap* for sake of simplifying testing between dap and godap
 WORKDIR /go/src/dap

--- a/Dockerfile.bats_testing
+++ b/Dockerfile.bats_testing
@@ -8,13 +8,14 @@ RUN git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh
 RUN apt-get install -y libpcap0.8-dev libgeoip-dev jq
 
 # build and install godap, but call it *dap* for sake of simplifying testing between dap and godap
-WORKDIR /go/src/dap
+ENV GOPATH=/go
+WORKDIR $GOPATH/src/github.com/rapid7/godap
 COPY . .
 RUN go get -d -v ./...
 RUN go install -v ./...
 
 # set default dap command
-ENV DAP_EXECUTABLE=dap
+ENV DAP_EXECUTABLE=godap
 
 # find and run all .bats files
 ENTRYPOINT /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/filter/errors.go
+++ b/filter/errors.go
@@ -1,0 +1,10 @@
+package filter
+
+import (
+	"errors"
+)
+
+var (
+	ErrNoArgs         = errors.New("Arguments must be supplied")
+	ErrInvalidMapArgs = errors.New("Expected two parameters in the format <key>=<value>")
+)

--- a/filter/recog.go
+++ b/filter/recog.go
@@ -1,7 +1,6 @@
 package filter
 
 import (
-	"errors"
 	"fmt"
 	recog "github.com/hdm/recog-go/pkg/nition"
 	"github.com/rapid7/godap/api"
@@ -44,8 +43,13 @@ func (fr *FilterRecog) Process(doc map[string]interface{}) (res []map[string]int
 func NewFilterRecog(mapped_fields map[string]string, dbpath string) (filterRecog *FilterRecog, err error) {
 	filterRecog = new(FilterRecog)
 
-	if mapped_fields == nil {
-		return nil, errors.New("Mapped fields must be supplied")
+	if mapped_fields == nil || len(mapped_fields) == 0 {
+		return nil, ErrNoArgs
+	}
+	for k, v := range mapped_fields {
+		if k == "" || v == "" {
+			return nil, ErrInvalidMapArgs
+		}
 	}
 	filterRecog.mapped_fields = mapped_fields
 
@@ -62,13 +66,13 @@ func NewFilterRecog(mapped_fields map[string]string, dbpath string) (filterRecog
 
 // Registers this plugin under the "recog" filter name
 //
-// If the `RECOG_DATABASE_DIRECTORY` environment variable is specified, this plugin
+// If the `RECOG_DATABASE_PATH` environment variable is specified, this plugin
 // will use that directory to load recog content. If it is not specified, it will load
 // content that is embedded in the `recog-go` package.
 func init() {
 	factory.RegisterFilter("recog", func(args []string) (filterRecog api.Filter, err error) {
 		opts := util.ParseOpts(args)
-		filterRecog, err = NewFilterRecog(opts, os.Getenv("RECOG_DATABASE_DIRECTORY"))
+		filterRecog, err = NewFilterRecog(opts, os.Getenv("RECOG_DATABASE_PATH"))
 		return
 	})
 }

--- a/filter/recog.go
+++ b/filter/recog.go
@@ -1,0 +1,39 @@
+package filter
+
+import (
+	"fmt"
+	recog "github.com/hdm/recog-go/pkg/nition"
+	"github.com/rapid7/godap/api"
+	"github.com/rapid7/godap/factory"
+)
+
+type FilterRecog struct {
+	BaseFilter
+	nizer *recog.FingerprintSet
+}
+
+func (fr *FilterRecog) Process(doc map[string]interface{}) (res []map[string]interface{}, err error) {
+	for match_field, match_db := range fr.opts {
+		if field_value_untyped, ok := doc[match_field]; ok {
+			if field_value, ok := field_value_untyped.(string); ok {
+				m := fr.nizer.MatchFirst(match_db, field_value)
+				if m.Matched {
+					for k, v := range m.Values {
+						doc[fmt.Sprintf("%s.recog.%s", match_field, k)] = v
+					}
+				}
+			}
+
+		}
+	}
+	return []map[string]interface{}{doc}, nil
+}
+
+func init() {
+	factory.RegisterFilter("recog", func(args []string) (lines api.Filter, err error) {
+		filterRecog := &FilterRecog{}
+		filterRecog.ParseOpts(args)
+		filterRecog.nizer = recog.MustLoadFingerprints()
+		return filterRecog, nil
+	})
+}

--- a/filter/recog.go
+++ b/filter/recog.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"errors"
 	"fmt"
 	recog "github.com/hdm/recog-go/pkg/nition"
 	"github.com/rapid7/godap/api"
@@ -42,6 +43,10 @@ func (fr *FilterRecog) Process(doc map[string]interface{}) (res []map[string]int
 // embedded in the recog-go package.
 func NewFilterRecog(mapped_fields map[string]string, dbpath string) (filterRecog *FilterRecog, err error) {
 	filterRecog = new(FilterRecog)
+
+	if mapped_fields == nil {
+		return nil, errors.New("Mapped fields must be supplied")
+	}
 	filterRecog.mapped_fields = mapped_fields
 
 	if dbpath == "" {

--- a/filter/recog_test.go
+++ b/filter/recog_test.go
@@ -16,6 +16,10 @@ func TestRecogFilterProcessingBehavior(t *testing.T) {
 				"input": "9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2",
 			})
 
+			Convey("There should only be one document", func() {
+				So(result, ShouldHaveLength, 1)
+			})
+
 			Convey("The document should contain recog fields", func() {
 				So(result[0]["input.recog.service.product"], ShouldEqual, "BIND")
 			})

--- a/filter/recog_test.go
+++ b/filter/recog_test.go
@@ -26,12 +26,17 @@ func TestRecogFilterProcessingBehavior(t *testing.T) {
 		})
 
 		Convey("When we process an input doc with no keys matching the filter's mapped fields", func() {
-			result, _ := filterRecog.Process(map[string]interface{}{
+			match_fields := map[string]interface{}{
 				"unmatched_field": "9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2",
+			}
+			result, _ := filterRecog.Process(match_fields)
+
+			Convey("There should be only one result document", func() {
+				So(result, ShouldHaveLength, 1)
 			})
 
-			Convey("There should be no recog fields in the result document", func() {
-				So(result[0]["input.recog.service.product"], ShouldEqual, nil)
+			Convey("The result document should equal the input document", func() {
+				So(result[0], ShouldResemble, match_fields)
 			})
 		})
 	})
@@ -57,7 +62,7 @@ func TestRecogFilterDatabaseLoading(t *testing.T) {
 			So(filterRecog, ShouldNotBeNil)
 		})
 
-		Convey("The error returned by NewFilterRecog should be nil", func() {
+		Convey("The error returned by NewFilterRecog should be unset (nil)", func() {
 			So(err, ShouldBeNil)
 		})
 	})

--- a/filter/recog_test.go
+++ b/filter/recog_test.go
@@ -1,0 +1,33 @@
+package filter
+
+import (
+	"strings"
+	"testing"
+)
+
+// Ensures that the recog library uses the file name of the recog
+// fingerprint database. This condition is tested by looking for
+// _any_ recog field within the result document returned by the
+// filter.
+func TestUsesFilenameForDatabaseName(t *testing.T) {
+	// given
+	filterRecog := NewFilterRecog(map[string]string{
+		"input": "dns_versionbind.xml",
+	})
+
+	// when
+	result, _ := filterRecog.Process(map[string]interface{}{
+		"input": "9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2",
+	})
+
+	// then
+	has_recog := false
+	for k, _ := range result[0] {
+		if strings.Contains(k, ".recog.") {
+			has_recog = true
+		}
+	}
+	if !has_recog {
+		t.Errorf("No recog fields present in %s", result)
+	}
+}

--- a/filter/recog_test.go
+++ b/filter/recog_test.go
@@ -1,33 +1,60 @@
 package filter
 
 import (
-	"strings"
+	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 )
 
-// Ensures that the recog library uses the file name of the recog
-// fingerprint database. This condition is tested by looking for
-// _any_ recog field within the result document returned by the
-// filter.
-func TestUsesFilenameForDatabaseName(t *testing.T) {
-	// given
-	filterRecog := NewFilterRecog(map[string]string{
-		"input": "dns_versionbind.xml",
+func TestRecogFilterProcessingBehavior(t *testing.T) {
+	Convey("Given a recog filter with a mapped field of \"input\" to dns.versionbind", t, func() {
+		filterRecog, _ := NewFilterRecog(map[string]string{
+			"input": "dns.versionbind",
+		}, "")
+
+		Convey("When we process an input doc with a RHEL DNS banner", func() {
+			result, _ := filterRecog.Process(map[string]interface{}{
+				"input": "9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2",
+			})
+
+			Convey("The document should contain recog fields", func() {
+				So(result[0]["input.recog.service.product"], ShouldEqual, "BIND")
+			})
+		})
+
+		Convey("When we process an input doc with no keys matching the filter's mapped fields", func() {
+			result, _ := filterRecog.Process(map[string]interface{}{
+				"unmatched_field": "9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2",
+			})
+
+			Convey("There should be no recog fields in the result document", func() {
+				So(result[0]["input.recog.service.product"], ShouldEqual, nil)
+			})
+		})
+	})
+}
+
+func TestRecogFilterDatabaseLoading(t *testing.T) {
+	Convey("Given a new recog filter created with an invalid database path", t, func() {
+		filterRecog, err := NewFilterRecog(map[string]string{"some": "field"}, "/some/invalid/path")
+
+		Convey("The recog filter should be nil", func() {
+			So(filterRecog, ShouldEqual, nil)
+		})
+
+		Convey("The error returned by NewFilterRecog should be set", func() {
+			So(err, ShouldBeError)
+		})
 	})
 
-	// when
-	result, _ := filterRecog.Process(map[string]interface{}{
-		"input": "9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2",
-	})
+	Convey("Given a new recog filter created with an empty database path", t, func() {
+		filterRecog, err := NewFilterRecog(map[string]string{"some": "field"}, "")
 
-	// then
-	has_recog := false
-	for k, _ := range result[0] {
-		if strings.Contains(k, ".recog.") {
-			has_recog = true
-		}
-	}
-	if !has_recog {
-		t.Errorf("No recog fields present in %s", result)
-	}
+		Convey("The recog filter should be non-nil", func() {
+			So(filterRecog, ShouldNotBeNil)
+		})
+
+		Convey("The error returned by NewFilterRecog should be nil", func() {
+			So(err, ShouldBeNil)
+		})
+	})
 }

--- a/filter/recog_test.go
+++ b/filter/recog_test.go
@@ -6,6 +6,18 @@ import (
 )
 
 func TestRecogFilterProcessingBehavior(t *testing.T) {
+	Convey("Given a recog filter with a nil mapped field map", t, func() {
+		filterRecog, err := NewFilterRecog(nil, "")
+
+		Convey("The recog filter should be nil", func() {
+			So(filterRecog, ShouldBeNil)
+		})
+
+		Convey("The error should be set (non-nil)", func() {
+			So(err, ShouldBeError)
+		})
+	})
+
 	Convey("Given a recog filter with a mapped field of \"input\" to dns.versionbind", t, func() {
 		filterRecog, _ := NewFilterRecog(map[string]string{
 			"input": "dns.versionbind",

--- a/test/filters.bats
+++ b/test/filters.bats
@@ -105,3 +105,20 @@ load ./test_common
   assert_success
   assert_output '{"foo":"YmFy"}'
 }
+
+@test "recog_match" {
+  run bash -c "echo '9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2' | $DAP_EXECUTABLE lines + recog line=dns.versionbind + json | jq -Sc ."
+  assert_success
+  assert_output '{"line":"9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2","line.recog.os.cpe23":"cpe:/o:redhat:enterprise_linux:6","line.recog.os.family":"Linux","line.recog.os.product":"Enterprise Linux","line.recog.os.vendor":"Red Hat","line.recog.os.version":"6","line.recog.os.version.version":"9","line.recog.service.cpe23":"cpe:/a:isc:bind:9.8.2rc1","line.recog.service.family":"BIND","line.recog.service.product":"BIND","line.recog.service.vendor":"ISC","line.recog.service.version":"9.8.2rc1"}'
+}
+
+@test "recog_nomatch" {
+  run bash -c "echo 'should not match' | $DAP_EXECUTABLE lines + recog line=dns.versionbind + json | jq -Sc ."
+  assert_success
+  assert_output '{"line":"should not match"}'
+}
+
+@test "recog_invalid_arg" {
+  run bash -c "echo 'test' | $DAP_EXECUTABLE lines + recog + json"
+  assert_failure
+}


### PR DESCRIPTION
# What is this?

This patch adds `recog` support based on @hdm's port of recog to go: https://github.com/hdm/recog-go.

This enables users of godap to feed lines into recog for automated fingerprinting use cases.

# Testing done

Automated testing using `goconvey`. See `recog_test.go`