### PR TITLE
parameterize bats dap executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 
 before_install:
   - docker build -t godap-bats -f Dockerfile.bats_testing .
-  - docker run godap-bats
+  - docker run -e DAP_EXECUTABLE=dap godap-bats

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 
 before_install:
   - docker build -t godap-bats -f Dockerfile.bats_testing .
-  - docker run -e DAP_EXECUTABLE=dap godap-bats
+  - docker run godap-bats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,17 @@ If you'd like to contribute, please fork this repository and publish PRs for rev
 
 # Testing
 
-[bats](https://github.com/sstephenson/bats) is currently used to run functional
-tests that exercise tests for `godap`.  [travis-ci](https://travis-ci.com) will
-automatically run all `bats` tests defined in this project upon each PR.  You
-are encouraged to add tests as you add/convert functionality.
+There are two testing frameworks in place.
+
+Code-level tests are required, and must be written in [goconvey](https://github.com/smartystreets/goconvey).
+This library allows behavior-driven development and testing. It is also compatible with standard golaing 
+`testing.T`.
+
+
+Additionally, [bats](https://github.com/sstephenson/bats) is currently used to run integration
+tests.  [travis-ci](https://travis-ci.com) will automatically run all `bats` tests defined in this project 
+upon each PR.  You are encouraged to add tests as you add/convert functionality from ruby-based dap to make
+the port easier.
 
 To run tests outside of travis-ci:
 

--- a/Dockerfile.bats_testing
+++ b/Dockerfile.bats_testing
@@ -13,5 +13,8 @@ COPY . .
 RUN go get -d -v ./...
 RUN go install -v ./...
 
+# set default dap command
+ENV DAP_EXECUTABLE=dap
+
 # find and run all .bats files
 ENTRYPOINT /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/test/filters.bats
+++ b/test/filters.bats
@@ -3,105 +3,105 @@
 load ./test_common
 
 @test "rename" {
-  run bash -c 'echo world | dap lines + rename line=hello + json'
+  run bash -c 'echo world | $DAP_EXECUTABLE lines + rename line=hello + json'
   assert_success
   assert_output '{"hello":"world"}'
 }
 
 @test "not_exists" {
-  run bash -c "echo '{\"foo\":\"bar\"}' | dap json + not_exists foo + json"
+  run bash -c "echo '{\"foo\":\"bar\"}' | $DAP_EXECUTABLE json + not_exists foo + json"
   assert_success
   assert_output ''
-  run bash -c "echo '{\"bar\":\"bar\"}' | dap json + not_exists foo + json"
+  run bash -c "echo '{\"bar\":\"bar\"}' | $DAP_EXECUTABLE json + not_exists foo + json"
   assert_success
   assert_output '{"bar":"bar"}'
 }
 
 @test "split_comma" {
-  run bash -c "echo '{\"foo\":\"bar,baz\"}' | dap json + split_comma foo + json"
+  run bash -c "echo '{\"foo\":\"bar,baz\"}' | $DAP_EXECUTABLE json + split_comma foo + json"
   assert_success
   assert_line --index 0 '{"foo":"bar,baz","foo.word":"bar"}'
   assert_line --index 1 '{"foo":"bar,baz","foo.word":"baz"}'
 }
 
 @test "field_split_line" {
-  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | dap json + field_split_line foo + json"
+  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | $DAP_EXECUTABLE json + field_split_line foo + json"
   assert_success
   assert_output '{"foo":"bar\nbaz","foo.f1":"bar","foo.f2":"baz"}'
 }
 
 @test "not_empty" {
-  run bash -c "echo '{\"foo\":\"bar,baz\"}' | dap json + not_empty foo + json"
+  run bash -c "echo '{\"foo\":\"bar,baz\"}' | $DAP_EXECUTABLE json + not_empty foo + json"
   assert_success
   assert_output '{"foo":"bar,baz"}'
 }
 
 @test "field_split_tab" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + field_split_tab foo + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + field_split_tab foo + json"
   assert_success
   assert_output '{"foo":"bar\tbaz","foo.f1":"bar","foo.f2":"baz"}'
 }
 
 @test "truncate" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + truncate foo + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + truncate foo + json"
   assert_success
   assert_output '{"foo":""}'
 }
 
 @test "insert" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + insert a=b + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + insert a=b + json"
   assert_success
   assert_output '{"a":"b","foo":"bar\tbaz"}'
 }
 
 @test "field_split_array" {
-  run bash -c "echo '{\"foo\":[\"a\",2]}' | dap json + field_split_array foo + json"
+  run bash -c "echo '{\"foo\":[\"a\",2]}' | $DAP_EXECUTABLE json + field_split_array foo + json"
   assert_success
   assert_output '{"foo":["a",2],"foo.f1":"a","foo.f2":2}'
 }
 
 @test "exists" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + exists a + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + exists a + json"
   assert_success
   assert_output ''
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + exists foo + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + exists foo + json"
   assert_success
   assert_output '{"foo":"bar\tbaz"}'
 }
 
 @test "split_line" {
-  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | dap json + split_line foo + json"
+  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | $DAP_EXECUTABLE json + split_line foo + json"
   assert_success
   assert_line --index 0 '{"foo":"bar\nbaz","foo.line":"bar"}'
   assert_line --index 1 '{"foo":"bar\nbaz","foo.line":"baz"}'
 }
 
 @test "select" {
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + select foo + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + select foo + json"
   assert_success
   assert_output '{"foo":"bar"}'
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + select foo baz + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + select foo baz + json"
   assert_success
   assert_output '{"baz":"qux","foo":"bar"}'
 }
 
 @test "remove" {
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + remove foo baz + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + remove foo baz + json"
   assert_success
   assert_output '{"a":"b"}'
 }
 
 @test "include" {
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + include a=c + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + include a=c + json"
   assert_success
   assert_output ''
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + include a=b + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + include a=b + json"
   assert_success
   assert_output '{"a":"b","baz":"qux","foo":"bar"}'
 }
 
 @test "transform" {
-  run bash -c "echo '{\"foo\":\"bar\"}' | dap json + transform foo=base64encode + json"
+  run bash -c "echo '{\"foo\":\"bar\"}' | $DAP_EXECUTABLE json + transform foo=base64encode + json"
   assert_success
   assert_output '{"foo":"YmFy"}'
 }

--- a/test/inputs.bats
+++ b/test/inputs.bats
@@ -3,13 +3,13 @@
 load ./test_common
 
 @test "reads json" {
-  run bash -c 'echo "{\"foo\": 1 }" | dap json + json'
+  run bash -c 'echo "{\"foo\": 1 }" | $DAP_EXECUTABLE json + json'
   assert_success
   assert_output '{"foo":1}'
 }
 
 @test "reads lines" {
-  run bash -c 'echo hello world | dap lines + json'
+  run bash -c 'echo hello world | $DAP_EXECUTABLE lines + json'
   assert_success
   assert_output '{"line":"hello world"}'
 }


### PR DESCRIPTION
Adds `$DAP_EXECUTABLE` to the filters and .travis.yml so the dap executable can be specified at runtime. This is useful for local runs of bats without having to run the docker container (avoiding constant rebuilds).