### PR TITLE
Run unit tests with bats tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ before_install:
   - docker build -t godap-bats -f Dockerfile.testing .
 
 script:
-  - docker build -t godap_bats -f Dockerfile.testing . && docker run --rm --name godap_bats -it -e DAP_EXECUTABLE=godap godap_bats /bin/bash -c "go test -v ./... && find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
+  - docker build -t godap_bats -f Dockerfile.testing .
+  - docker run --rm --name godap_bats -it -e DAP_EXECUTABLE=godap godap_bats /bin/bash -c "go test -v -tags=\"libpcap libgeoip\" ./... && find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ services:
   - docker
 
 before_install:
-  - docker build -t godap-bats -f Dockerfile.bats_testing .
-  - docker run godap-bats
+  - docker build -t godap-bats -f Dockerfile.testing .
+
+script:
+  - docker build -t godap_bats -f Dockerfile.testing . && docker run --rm --name godap_bats -it -e DAP_EXECUTABLE=godap godap_bats /bin/bash -c "go test -v ./... && find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,6 @@ the port easier.
 To run tests outside of travis-ci:
 
 ```
-docker build -t godap_bats -f Dockerfile.testing . && docker run --rm --name godap_bats -it -e DAP_EXECUTABLE=godap godap_bats /bin/bash -c "go test -v ./... && find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
+docker build -t godap_bats -f Dockerfile.testing . && \
+docker run --rm --name godap_bats -it -e DAP_EXECUTABLE=godap godap_bats /bin/bash -c "go test -v -tags=\"libpcap libgeoip\" ./... && find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ the port easier.
 To run tests outside of travis-ci:
 
 ```
-docker build -t godap_bats -f Dockerfile.bats_testing . &&  docker run --rm -it --name godap_bats -v "$PWD":/opt/bats_testing godap_bats
+docker build -t godap_bats -f Dockerfile.testing . && docker run --rm --name godap_bats -it -e DAP_EXECUTABLE=godap godap_bats /bin/bash -c "go test -v ./... && find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
 ```

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -8,14 +8,6 @@ RUN git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh
 RUN apt-get install -y libpcap0.8-dev libgeoip-dev jq
 
 # build and install godap, but call it *dap* for sake of simplifying testing between dap and godap
-ENV GOPATH=/go
-WORKDIR $GOPATH/src/github.com/rapid7/godap
+WORKDIR /opt/godap
 COPY . .
-RUN go get -d -v -tags="libpcap libgeoip" ./...
-RUN go install -v -tags="libpcap libgeoip" ./...
-
-# set default dap command
-ENV DAP_EXECUTABLE=godap
-
-# find and run all .bats files
-ENTRYPOINT /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
+RUN go install -v -tags="libpcap libgeoip"


### PR DESCRIPTION
This change removes the ENTRYPOINT from the Dockerfile so the same docker container can be used as an un-opinionated container for running either go or bats tests.

This has a minor effect of making the commandline to run all tests slightly longer. However, this can be encapsulated into a `Makefile` later.